### PR TITLE
Detect path of rsession in default rstudio install automatically

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import subprocess
 import getpass
+import shutil
 from textwrap import dedent
 
 def setup_shiny():
@@ -56,16 +57,25 @@ def setup_rstudio():
             'RSTUDIO_DEFAULT_R_VERSION': version,
         }
 
-    return {
-        'command': [
-            'rsession',
+    def _get_rsession_cmd(port):
+        if shutil.which('rsession'):
+            executable = 'rsession'
+        else:
+            # Default path for rsession if installed with the deb package
+            executable = '/usr/lib/rstudio-server/bin/rsession'
+
+        return [
+            executable,
             '--standalone=1',
             '--program-mode=server',
             '--log-stderr=1',
             '--session-timeout-minutes=0',
             '--user-identity=' + getpass.getuser(),
-            '--www-port={port}'
-        ],
+            '--www-port=' + str(port)
+        ]
+
+    return {
+        'command': _get_rsession_cmd,
         'environment': _get_rsession_env,
         'title': 'RStudio',
         'icon': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg')

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -58,11 +58,22 @@ def setup_rstudio():
         }
 
     def _get_rsession_cmd(port):
+        # Other paths rsession maybe in
+        other_paths = [
+            # When rstudio-server deb is installed
+            '/usr/lib/rstudio-server/bin/rsession',
+            # When just rstudio deb is installed
+            '/usr/lib/rstudio/bin/rsession',
+        ]
         if shutil.which('rsession'):
             executable = 'rsession'
         else:
-            # Default path for rsession if installed with the deb package
-            executable = '/usr/lib/rstudio-server/bin/rsession'
+            for op in other_paths:
+                if os.path.exists(op):
+                    executable = op
+                    break
+            else:
+                raise FileNotFoundError('Can not find rsession in PATH')
 
         return [
             executable,


### PR DESCRIPTION
For some reason the rstudio deb doesn't put executables in
the normal locations