### PR TITLE
Switch back to using rserver

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -40,56 +40,34 @@ def setup_shiny():
     }
 
 def setup_rstudio():
-    def _get_rsession_env(port):
-        # Detect various environment variables rsession requires to run
-        # Via rstudio's src/cpp/core/r_util/REnvironmentPosix.cpp
-        cmd = ['R', '--slave', '--vanilla', '-e',
-                'cat(paste(R.home("home"),R.home("share"),R.home("include"),R.home("doc"),getRversion(),sep=":"))']
-
-        r_output = subprocess.check_output(cmd)
-        R_HOME, R_SHARE_DIR, R_INCLUDE_DIR, R_DOC_DIR, version = \
-            r_output.decode().split(':')
-
-        return {
-            'R_DOC_DIR': R_DOC_DIR,
-            'R_HOME': R_HOME,
-            'R_INCLUDE_DIR': R_INCLUDE_DIR,
-            'R_SHARE_DIR': R_SHARE_DIR,
-            'RSTUDIO_DEFAULT_R_VERSION_HOME': R_HOME,
-            'RSTUDIO_DEFAULT_R_VERSION': version,
-        }
-
-    def _get_rsession_cmd(port):
+    def _get_rserver_cmd(port):
         # Other paths rsession maybe in
         other_paths = [
             # When rstudio-server deb is installed
-            '/usr/lib/rstudio-server/bin/rsession',
+            '/usr/lib/rstudio-server/bin/rserver',
             # When just rstudio deb is installed
-            '/usr/lib/rstudio/bin/rsession',
+            '/usr/lib/rstudio/bin/rserver',
         ]
-        if shutil.which('rsession'):
-            executable = 'rsession'
+        if shutil.which('rserver'):
+            executable = 'rserver'
         else:
             for op in other_paths:
                 if os.path.exists(op):
                     executable = op
                     break
             else:
-                raise FileNotFoundError('Can not find rsession in PATH')
+                raise FileNotFoundError('Can not find rserver in PATH')
 
         return [
             executable,
-            '--standalone=1',
-            '--program-mode=server',
-            '--log-stderr=1',
-            '--session-timeout-minutes=0',
-            '--user-identity=' + getpass.getuser(),
             '--www-port=' + str(port)
         ]
 
     return {
-        'command': _get_rsession_cmd,
-        'environment': _get_rsession_env,
+        'command': _get_rserver_cmd,
+        'environment': {
+            'USER': getpass.getuser()
+        },
         'launcher_entry': {
             'title': 'RStudio',
             'icon_path': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="jupyter-rsession-proxy",
-    version='1.0dev',
+    version='1.0beta6',
     url="https://github.com/jupyterhub/jupyter-rsession-proxy",
     author="Ryan Lovett & Yuvi Panda",
     description="Jupyter extension to proxy RStudio's rsession",


### PR DESCRIPTION
- rsession doesn't work well with proxying shiny apps
- There seem to be problems with restarting too

This means we leave zombie rstudio processes behind -
it daemonizes and we can't reap it :(

See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/56