### PR TITLE
Include LICENSE.txt in sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
It's always nice to ship the LICENSE with the package.