### PR TITLE
Add conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ Note that rstudio server is needed to work with this extension.
 
 ### Install jupyter-rsession-proxy
 
-Install the library:
+Install the library via `pip`:
 ```
 pip install jupyter-rsession-proxy
+```
+Or via `conda`:
+```
+conda install -c conda-forge jupyter-rsession-proxy
 ```
 
 The Dockerfile contains an example installation on top of [jupyter/r-notebook](https://github.com/jupyter/docker-stacks/tree/master/r-notebook).


### PR DESCRIPTION
`jupyter-rsession-proxy` is now also available as a conda package: https://github.com/conda-forge/jupyter-rsession-proxy-feedstock