### PR TITLE
Switch back to rserver from rsession

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -14,11 +14,11 @@ def get_rstudio_executable(prog):
     if shutil.which(prog):
         return prog
 
-	for op in other_paths:
-		if os.path.exists(op):
-			return op
+    for op in other_paths:
+        if os.path.exists(op):
+            return op
 
-	raise FileNotFoundError(f'Could not find {prog} in PATH')
+    raise FileNotFoundError(f'Could not find {prog} in PATH')
 
 def setup_rserver():
     def _get_env(port):

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -20,6 +20,11 @@ def get_rstudio_executable(prog):
 
     raise FileNotFoundError(f'Could not find {prog} in PATH')
 
+def get_icon_path():
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg'
+    )
+
 def setup_rserver():
     def _get_env(port):
         return dict(USER=getpass.getuser())
@@ -34,8 +39,8 @@ def setup_rserver():
         'command': _get_cmd,
         'environment': _get_env,
         'launcher_entry': {
-            'title': 'RStudio Server',
-            'icon_path': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg')
+            'title': 'RStudio',
+            'icon_path': get_icon_path()
         }
     }
 
@@ -75,9 +80,6 @@ def setup_rsession():
         'environment': _get_env,
         'launcher_entry': {
             'title': 'RStudio',
-            'icon_path': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg')
+            'icon_path': get_icon_path()
         }
     }
-
-def setup_rstudio():
-    return setup_rsession()

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -3,8 +3,44 @@ import subprocess
 import getpass
 import shutil
 
-def setup_rstudio():
-    def _get_rsession_env(port):
+def get_rstudio_executable(prog):
+    # Find prog in known locations
+    other_paths = [
+        # When rstudio-server deb is installed
+        os.path.join('/usr/lib/rstudio-server/bin', prog),
+        # When just rstudio deb is installed
+        os.path.join('/usr/lib/rstudio/bin', prog),
+    ]
+    if shutil.which(prog):
+        return prog
+
+	for op in other_paths:
+		if os.path.exists(op):
+			return op
+
+	raise FileNotFoundError(f'Could not find {prog} in PATH')
+
+def setup_rserver():
+    def _get_env(port):
+        return dict(USER=getpass.getuser())
+
+    def _get_cmd(port):
+        return [
+            get_rstudio_executable('rserver'),
+            '--www-port=' + str(port)
+        ]
+
+    return {
+        'command': _get_cmd,
+        'environment': _get_env,
+        'launcher_entry': {
+            'title': 'RStudio Server',
+            'icon_path': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg')
+        }
+    }
+
+def setup_rsession():
+    def _get_env(port):
         # Detect various environment variables rsession requires to run
         # Via rstudio's src/cpp/core/r_util/REnvironmentPosix.cpp
         cmd = ['R', '--slave', '--vanilla', '-e',
@@ -23,26 +59,9 @@ def setup_rstudio():
             'RSTUDIO_DEFAULT_R_VERSION': version,
         }
 
-    def _get_rsession_cmd(port):
-        # Other paths rsession maybe in
-        other_paths = [
-            # When rstudio-server deb is installed
-            '/usr/lib/rstudio-server/bin/rsession',
-            # When just rstudio deb is installed
-            '/usr/lib/rstudio/bin/rsession',
-        ]
-        if shutil.which('rsession'):
-            executable = 'rsession'
-        else:
-            for op in other_paths:
-                if os.path.exists(op):
-                    executable = op
-                    break
-            else:
-                raise FileNotFoundError('Can not find rsession in PATH')
-
+    def _get_cmd(port):
         return [
-            executable,
+            get_rstudio_executable('rsession'),
             '--standalone=1',
             '--program-mode=server',
             '--log-stderr=1',
@@ -52,10 +71,13 @@ def setup_rstudio():
         ]
 
     return {
-        'command': _get_rsession_cmd,
-        'environment': _get_rsession_env,
+        'command': _get_cmd,
+        'environment': _get_env,
         'launcher_entry': {
             'title': 'RStudio',
             'icon_path': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg')
         }
     }
+
+def setup_rstudio():
+    return setup_rsession()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     ],
     entry_points={
         'jupyter_serverproxy_servers': [
+            'rserver = jupyter_rsession_proxy:setup_rserver',
             'rstudio = jupyter_rsession_proxy:setup_rstudio'
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ setuptools.setup(
     ],
     entry_points={
         'jupyter_serverproxy_servers': [
-            'rserver = jupyter_rsession_proxy:setup_rserver',
-            'rstudio = jupyter_rsession_proxy:setup_rstudio'
+            'rstudio = jupyter_rsession_proxy:setup_rserver'
         ]
     },
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     version='1.0',
     url="https://github.com/jupyterhub/jupyter-rsession-proxy",
     author="Ryan Lovett & Yuvi Panda",
-    description="Jupyter extension to proxy RStudio's rsession",
+    description="Jupyter extension to proxy RStudio",
     packages=setuptools.find_packages(),
 	keywords=['Jupyter'],
 	classifiers=['Framework :: Jupyter'],


### PR DESCRIPTION
Preserve rsession support, at least in the short term. People can manually override the entry point if they need rsession. If it becomes important to support rsession during install, we can try adding a parameter to setup.py or some such thing. I don't think we want to support both at run time because I think it'd be confusing for users to have to choose between RStudio and RStudio Session, or RStudio Server and RStudio.