### PR TITLE
Permit rserver to run in a frame of same origin as rstudio.

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -32,7 +32,8 @@ def setup_rserver():
     def _get_cmd(port):
         return [
             get_rstudio_executable('rserver'),
-            '--www-port=' + str(port)
+            '--www-port=' + str(port),
+            '--www-frame-origin=same'
         ]
 
     return {


### PR DESCRIPTION
Required for RStudio to run in a jupyterlab tab.