### PR TITLE
Use random temporary file name for rserver secure cookie key

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -3,6 +3,8 @@ import subprocess
 import getpass
 import shutil
 
+from tempfile import NamedTemporaryFile
+
 def get_rstudio_executable(prog):
     # Find prog in known locations
     other_paths = [
@@ -30,10 +32,12 @@ def setup_rserver():
         return dict(USER=getpass.getuser())
 
     def _get_cmd(port):
+        ntf = NamedTemporaryFile(prefix='/tmp/')
         return [
             get_rstudio_executable('rserver'),
             '--www-port=' + str(port),
-            '--www-frame-origin=same'
+            '--www-frame-origin=same',
+            '--secure-cookie-key-file=' + ntf.name
         ]
 
     return {


### PR DESCRIPTION
When using the batchspawner, we can have several rserver session started on the same cluster node. However, rserver is by default using the same path `/tmp/rstudio-server/secure-cookie-key` to store secure cookie key. As a result the cookie key file is locked and owned by the first user starting a RStudio session on a given node.
To avoid this, we need to define a distinct temporary file for rserver secure cookie key for each rserver instance.