### PR TITLE
Define /auth-sign-in as the initial URL to be launched

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -79,7 +79,8 @@ def setup_rserver():
         'environment': _get_env,
         'launcher_entry': {
             'title': 'RStudio',
-            'icon_path': get_icon_path()
+            'icon_path': get_icon_path(),
+            'launcher_url': '/auth-sign-in'
         }
     }
 

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -80,7 +80,7 @@ def setup_rserver():
         'launcher_entry': {
             'title': 'RStudio',
             'icon_path': get_icon_path(),
-            'launcher_url': '/auth-sign-in'
+            'launcher_url': '/auth-sign-in',
         }
     }
 


### PR DESCRIPTION
- If you are authenticated you are redirected to the main rstudio page correctly
- If you are unauthenticated, rstudio wants to redirect to that url but fails to do it properly (on 1.4)

So let's just change the link on the frontend to go by default to the right auth-sign-in url and problem solved

Depends on https://github.com/jupyterhub/jupyter-server-proxy/pull/278

Closes #97, related to #95 and #93