### PR TITLE
Rewrite /auth-sign-in redirect.

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -69,16 +69,24 @@ def setup_rserver():
         cmd = [
             get_rstudio_executable('rserver'),
             '--auth-none=1',
+            f'--server-user={getpass.getuser()}',
             '--www-frame-origin=same',
             '--www-port=' + str(port),
             '--www-verify-user-agent=0'
         ]
 
+        try:
+            detect_version()
+        except:
+            pass
+        finally:
+            version_ge_1_4 = True
+
         # Add additional options for RStudio >= 1.4.x. Since we cannot
         # determine rserver's version from the executable, we must use
         # explicit configuration. In this case the environment variable
         # RSESSION_PROXY_RSTUDIO_1_4 must be set.
-        if os.environ.get('RSESSION_PROXY_RSTUDIO_1_4', False):
+        if version_ge_1_4 or os.environ.get('RSESSION_PROXY_RSTUDIO_1_4', False):
             # base_url has a trailing slash
             cmd.append('--www-root-path={base_url}rstudio/')
             cmd.append(f'--database-config-file={db_config()}')

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -28,6 +28,17 @@ def get_icon_path():
         os.path.dirname(os.path.abspath(__file__)), 'icons', 'rstudio.svg'
     )
 
+def detect_version():
+    '''
+    Detect version of rserver by running rsession. rserver does not have a
+    version flag. They are typically (always?) installed from the same
+    package.
+    '''
+    cmd = [get_rstudio_executable('rsession'), '--version']
+    output = subprocess.check_output(cmd)
+    version, rest = output.decode().split(',', 1)
+    return version
+
 def setup_rserver():
     def _get_env(port):
         return dict(USER=getpass.getuser())


### PR DESCRIPTION
This depends on https://github.com/jupyterhub/jupyter-server-proxy/pull/300 and is intended to fix #97.

It also removes the version environment variable and detection function. If/when this is merged we can bump the version dependency.