### PR TITLE
/var/run/rstudio is not writable by non root users

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -67,10 +67,11 @@ def setup_rserver():
         db_config_name = f.name
         f.write(db_conf)
         f.close()
-        return db_config_name
+        return db_config_name, db_dir
 
     def _get_cmd(port):
         ntf = tempfile.NamedTemporaryFile()
+        database_config_file, server_data_dir = db_config()
         cmd = [
             get_rstudio_executable('rserver'),
             '--auth-none=1',
@@ -80,7 +81,8 @@ def setup_rserver():
             '--secure-cookie-key-file=' + ntf.name,
             '--server-user=' + getpass.getuser(),
             '--www-root-path={base_url}rstudio/',
-            f'--database-config-file={db_config()}'
+            f'--database-config-file={database_config_file}',
+            f'--server-data-dir={server_data_dir}'
         ]
 
         return cmd

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -47,7 +47,7 @@ def setup_rserver():
     def _get_env(port):
         return dict(USER=getpass.getuser())
 
-    def db_config():
+    def db_config(db_dir):
         '''
         Create a temporary directory to hold rserver's database, and create
         the configuration file rserver uses to find the database.
@@ -55,9 +55,6 @@ def setup_rserver():
         https://docs.rstudio.com/ide/server-pro/latest/database.html
         https://github.com/rstudio/rstudio/tree/v1.4.1103/src/cpp/server/db
         '''
-        # use mkdtemp() so the directory and its contents don't vanish when
-        # we're out of scope
-        db_dir = tempfile.mkdtemp()
         # create the rserver database config
         db_conf = dedent("""
             provider=sqlite
@@ -71,7 +68,13 @@ def setup_rserver():
 
     def _get_cmd(port):
         ntf = tempfile.NamedTemporaryFile()
-        database_config_file, server_data_dir = db_config()
+
+        # use mkdtemp() so the directory and its contents don't vanish when
+        # we're out of scope
+        server_data_dir = tempfile.mkdtemp()
+
+        database_config_file = db_config(server_data_dir)
+
         cmd = [
             get_rstudio_executable('rserver'),
             '--auth-none=1',


### PR DESCRIPTION
@ryanlovett  I guess there are more elegant solutions, i can change it as you like.

If you do not want to fix it, it should be at least stated in the documentation that you have to `chmod 1777 /var/run/rstudio-server/` because there is zero logging and it takes a lot of time to find the reason for this error.

```
[~]$ /usr/lib/rstudio-server/bin/rserver --auth-none=1 --www-frame-origin=same --www-port=12345 --www-verify-user-agent=0 --secure-cookie-key-file=/tmp/tmpjqxz6d9a --server-user=1000890000 --www-root-path={base_url}rstudio/ --database-config-file=/tmp/tmpbtj913a_/tmp8ewz1mwb2021-12-03T11:07:59.337534Z [rserver] ERROR Could not change permissions for specified 'server-data-dir' - the directory (/var/run/rstudio-server) must be writeable by all users and have the sticky bit set; LOGGED FROM: int main(int, char* const*) src/cpp/server/ServerMain.cpp:684
2021-12-03T11:07:59.337944Z [rserver] ERROR system error 1 (Operation not permitted) [path: /var/run/rstudio-server]; OCCURRED AT rstudio::core::Error rstudio::core::{anonymous}::changeFileModeImpl(const string&, mode_t) src/cpp/shared_core/FilePath.cpp:313; LOGGED FROM: int main(int, char* const*) src/cpp/server/ServerMain.cpp:685
```