### PR TITLE
add 10s default timeout and environment varariable

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -98,8 +98,12 @@ def setup_rserver():
 
         return cmd
 
+    def _get_timeout(default=10):
+        return os.getenv('RSERVER_TIMEOUT', default)
+
     server_process = {
         'command': _get_cmd,
+        'timeout': _get_timeout,
         'environment': _get_env,
         'rewrite_response': rewrite_auth,
         'launcher_entry': {
@@ -140,8 +144,12 @@ def setup_rsession():
             '--www-port=' + str(port)
         ]
 
+    def _get_timeout(default=10):
+        return os.getenv('RSESSION_TIMEOUT', default)
+
     return {
         'command': _get_cmd,
+        'timeout': _get_timeout,
         'environment': _get_env,
         'launcher_entry': {
             'title': 'RStudio',

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -103,7 +103,7 @@ def setup_rserver():
 
     server_process = {
         'command': _get_cmd,
-        'timeout': _get_timeout,
+        'timeout': _get_timeout(),
         'environment': _get_env,
         'rewrite_response': rewrite_auth,
         'launcher_entry': {
@@ -149,7 +149,7 @@ def setup_rsession():
 
     return {
         'command': _get_cmd,
-        'timeout': _get_timeout,
+        'timeout': _get_timeout(),
         'environment': _get_env,
         'launcher_entry': {
             'title': 'RStudio',

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -98,7 +98,7 @@ def setup_rserver():
 
         return cmd
 
-    def _get_timeout(default=10):
+    def _get_timeout(default=15):
         return os.getenv('RSERVER_TIMEOUT', default)
 
     server_process = {
@@ -144,7 +144,7 @@ def setup_rsession():
             '--www-port=' + str(port)
         ]
 
-    def _get_timeout(default=10):
+    def _get_timeout(default=15):
         return os.getenv('RSESSION_TIMEOUT', default)
 
     return {


### PR DESCRIPTION
Increases start timeout from default 5s to 15s, and allows to override using ENV variables (RSERVER_TIMEOUT, RSESSION_TIMEOUT)

- having longer timeout helps in cases when start is actually slower for any reason

Fixes https://github.com/jupyterhub/jupyter-rsession-proxy/issues/127