### PR TITLE
use NB_USER rather than getpass.getuser()

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -45,7 +45,7 @@ def rewrite_auth(response, request):
 
 def setup_rserver():
     def _get_env(port):
-        return dict(USER=getpass.getuser())
+        return dict(USER=os.environ.get('NB_USER'))
 
     def db_config(db_dir):
         '''
@@ -85,7 +85,7 @@ def setup_rserver():
             '--www-port=' + str(port),
             '--www-verify-user-agent=0',
             '--secure-cookie-key-file=' + ntf.name,
-            '--server-user=' + getpass.getuser(),
+            '--server-user=' + os.environ.get('NB_USER'),
         ]
         # Support at least v1.2.1335 and up
 
@@ -136,7 +136,7 @@ def setup_rsession():
             '--program-mode=server',
             '--log-stderr=1',
             '--session-timeout-minutes=0',
-            '--user-identity=' + getpass.getuser(),
+            '--user-identity=' + os.environ.get('NB_USER'),
             '--www-port=' + str(port)
         ]
 


### PR DESCRIPTION
Potential fix for:
https://github.com/jupyterhub/jupyter-rsession-proxy/issues/129