### PR TITLE
add float conversion for timeout

### DIFF
--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -106,7 +106,10 @@ def setup_rserver():
         return cmd
 
     def _get_timeout(default=15):
-        return os.getenv('RSERVER_TIMEOUT', default)
+        try:
+            return float(os.getenv('RSERVER_TIMEOUT', default))
+        except Exception:
+            return default
 
     server_process = {
         'command': _get_cmd,
@@ -152,7 +155,10 @@ def setup_rsession():
         ]
 
     def _get_timeout(default=15):
-        return os.getenv('RSESSION_TIMEOUT', default)
+        try:
+            return float(os.getenv('RSESSION_TIMEOUT', default))
+        except Exception:
+            return default
 
     return {
         'command': _get_cmd,


### PR DESCRIPTION
I noticed that jupyter-server-proxy expects a float value for timeout, instead of string.

Currently setting environment variables throw this error:
```
[E 2022-10-11 11:24:26.180 SingleUserNotebookApp web:1798] Uncaught exception GET /user/test/rstudio/ (::ffff:172.18.0.1)
    HTTPServerRequest(protocol='http', host='www.localhost:8000', method='GET', uri='/user/test/rstudio/', version='HTTP/1.1', remote_ip='::ffff:172.18.0.1')
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.10/site-packages/tornado/web.py", line 1713, in _execute
        result = await result
      File "/opt/conda/lib/python3.10/site-packages/jupyter_server_proxy/websocket.py", line 91, in get
        return await self.http_get(*args, **kwargs)
      File "/opt/conda/lib/python3.10/site-packages/jupyter_server_proxy/handlers.py", line 683, in http_get
        return await ensure_async(self.proxy(self.port, path))
      File "/opt/conda/lib/python3.10/site-packages/jupyter_server/utils.py", line 182, in ensure_async
        result = await obj
      File "/opt/conda/lib/python3.10/site-packages/jupyter_server_proxy/handlers.py", line 677, in proxy
        await self.ensure_process()
      File "/opt/conda/lib/python3.10/site-packages/jupyter_server_proxy/handlers.py", line 656, in ensure_process
        is_ready = await proc.ready()
      File "/opt/conda/lib/python3.10/site-packages/simpervisor/process.py", line 182, in ready
        if time.time() - start_time > self.ready_timeout:
    TypeError: '>' not supported between instances of 'float' and 'str'
```