### PR TITLE
update install requirement (jupyter-server-proxy) for unix-socket-support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
 	keywords=['Jupyter'],
 	classifiers=['Framework :: Jupyter'],
     install_requires=[
-        'jupyter-server-proxy>=3.2.3,!=4.0.0,!=4.1.0'
+        'jupyter-server-proxy>4.1.0'
     ],
     entry_points={
         'jupyter_serverproxy_servers': [


### PR DESCRIPTION
jupyter-server-proxy introduced `unix-socket` in version 4.0 (released April 2023) with this commit https://github.com/jupyterhub/jupyter-server-proxy/commit/6cc7e6f13be8acb20fa1a3d72c7e327fa23e8841
Hence, we need to change the install requirements for jupyter-server-proxy to `>=4.0.0` for `unix-socket`-support.

I do not know the motivation for the current limitations of `!=4.0.0,!=4.1.0` so I propose a change from from
`'jupyter-server-proxy>=3.2.3,!=4.0.0,!=4.1.0'`
to
`'jupyter-server-proxy>4.1.0'`

P.S:  @yuvipanda I'm sorry this change slipped through when splitting PR https://github.com/jupyterhub/jupyter-rsession-proxy/pull/151 into https://github.com/jupyterhub/jupyter-rsession-proxy/pull/159 and https://github.com/jupyterhub/jupyter-rsession-proxy/pull/160

