### PR TITLE
Allow specifying server prefix and R path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Or via `conda`:
 conda install -c conda-forge jupyter-rsession-proxy
 ```
 
+### Traitlets configuration
+
+You may also manually configure this extension inside a [traitlets](https://traitlets.readthedocs.io/en/stable/) configuration file for [jupyter-server-proxy](https://jupyter-server-proxy.readthedocs.io/en/latest/server-process.html#specifying-config-via-traitlets). This also allows you to configure multiple different RStudio applications, for instance using different versions of R:
+
+```python
+from jupyter_rsession_proxy import setup_rserver
+# update the jupyter-server-proxy config by adding two RStudio servers
+c.ServerProxy.servers.update({
+  "rstudio1": setup_rserver(prefix="rstudio1", r_path="/usr/bin/R", launcher_title="RStudio (default R)"),
+  "rstudio2": setup_rserver(prefix="rstudio2", r_path="/opt/miniconda3/bin/R", launcher_title="RStudio (other R)")
+})
+# note that the prefix and the dict key are the same for each server (both "rstudio1" and "rstudio2", respectively).
+# this is necessary for everything to work correctly:
+# if prefix and dict key differ, then the user would not be redirected to the right URL.
+```
+
+Note: in this scenario, `jupyter-rsession-proxy` must still first be installed (into the same environment as Jupyter) as described [above](#install-jupyter-rsession-proxy).
+
+
 ## Example
 
 [rocker/binder](https://hub.docker.com/r/rocker/binder) contains an example installation which you can run on binder.

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -54,7 +54,7 @@ def get_system_user():
         user = os.getenv('NB_USER', getpass.getuser())
     return(user)
 
-def setup_rserver(r_path="", prefix="rstudio"):
+def setup_rserver(r_path="", prefix="rstudio", launcher_title="RStudio"):
     def _get_env(port, unix_socket):
         return dict(USER=get_system_user())
 
@@ -153,7 +153,7 @@ def setup_rserver(r_path="", prefix="rstudio"):
         'environment': _get_env,
         'rewrite_response': rewrite_netloc,
         'launcher_entry': {
-            'title': 'RStudio',
+            'title': launcher_title,
             'icon_path': get_icon_path()
         }
     }

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -54,7 +54,7 @@ def get_system_user():
         user = os.getenv('NB_USER', getpass.getuser())
     return(user)
 
-def setup_rserver():
+def setup_rserver(r_path="", prefix="rstudio"):
     def _get_env(port, unix_socket):
         return dict(USER=get_system_user())
 
@@ -112,13 +112,16 @@ def setup_rserver():
             'database-config-file',
             'www-thread-pool-size',
             'www-socket',
+            'rsession-which-r'
         ])
         if supported_args['www-root-path']:
-            cmd.append('--www-root-path={base_url}rstudio/')
+            cmd.append('--www-root-path={base_url}' + f'{prefix}/')
         if supported_args['server-data-dir']:
             cmd.append(f'--server-data-dir={server_data_dir}')
         if supported_args['database-config-file']:
             cmd.append(f'--database-config-file={database_config_file}')
+        if supported_args['rsession-which-r'] and r_path:
+            cmd.append(f'--rsession-which-r={r_path}')
 
         if supported_args['www-thread-pool-size']:
             thread_pool_size_env = os.getenv('JUPYTER_RSESSION_PROXY_THREAD_POOL_SIZE', None)

--- a/jupyter_rsession_proxy/__init__.py
+++ b/jupyter_rsession_proxy/__init__.py
@@ -115,7 +115,7 @@ def setup_rserver(r_path="", prefix="rstudio", launcher_title="RStudio"):
             'rsession-which-r'
         ])
         if supported_args['www-root-path']:
-            cmd.append('--www-root-path={base_url}' + f'{prefix}/')
+            cmd.append('--www-root-path={base_url}' + f'/{prefix}/')
         if supported_args['server-data-dir']:
             cmd.append(f'--server-data-dir={server_data_dir}')
         if supported_args['database-config-file']:


### PR DESCRIPTION
Thanks for this neat package!

I would like to use the `setup_rserver` function from this module to add *multiple* RStudio servers to a JupyterHub environment. This can in principle be done by manually calling `c.ServerProxy.servers.update({...})` from within a `jupyter-server-proxy` file. However, currently `setup_rserver` does not:

1. Allow specifying the server name (prefix)
2. Allow specifying the launcher entry title
3. Allow specifying the path to the R interpreter that should be used

This PR addresses these issues by adding optional keyword arguments to `setup_rserver`, and by using `rserver`'s `--rsession-which-r` option when it is available.

This makes it possible to add multiple servers from within a `jupyter-server` config file like so:

```python
from jupyter_rsession_proxy import setup_rserver
c.ServerProxy.servers.update({
  "rstudio1": setup_rserver(prefix="rstudio1", r_path="/usr/bin/R", launcher_title="RStudio (default R)"),
  "rstudio2": setup_rserver(prefix="rstudio2", r_path="/opt/miniconda3/bin/R", launcher_title="RStudio (other R)")
})
```