### PR TITLE
Add proxy tests

### DIFF
--- a/.github/workflows/test-jupyterhub.yaml
+++ b/.github/workflows/test-jupyterhub.yaml
@@ -1,0 +1,117 @@
+# Installs RStudio Server inside a JupyterHub user server and verifies the /rstudio/ proxy endpoint is reachable.
+name: Test JupyterHub
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+jobs:
+  test-jupyterhub:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/jupyter/r-notebook:latest
+      options: --user root
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js and configurable-http-proxy
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends nodejs npm
+          npm install -g configurable-http-proxy
+
+      - name: Install package and JupyterHub
+        run: pip install -e . jupyterhub
+
+      - name: Install RStudio Server
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends gdebi-core jq wget
+
+          RELEASE=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          RSTUDIO_URL=$(wget --output-document - --output-file /dev/null \
+            'https://www.rstudio.com/wp-content/downloads.json' \
+            | jq --raw-output --arg RELEASE "$RELEASE" \
+              '.rstudio.open_source.stable.server.installer[$RELEASE].url')
+
+          wget --no-verbose --output-document rstudio-server-latest-amd64.deb "$RSTUDIO_URL"
+          gdebi --non-interactive rstudio-server-latest-amd64.deb
+          rm rstudio-server-latest-amd64.deb
+
+      - name: Create system user and JupyterHub config
+        run: |
+          useradd -m testuser
+
+          cat > /tmp/jupyterhub_config.py << 'EOF'
+          c.JupyterHub.authenticator_class = 'dummy'
+          c.DummyAuthenticator.password = 'password'
+          c.JupyterHub.spawner_class = 'jupyterhub.spawner.LocalProcessSpawner'
+          c.Spawner.cmd = ['/opt/conda/bin/jupyterhub-singleuser']
+          c.Authenticator.admin_users = {'admin'}
+          c.JupyterHub.api_tokens = {'ci-admin-token': 'admin'}
+          EOF
+
+      - name: Start JupyterHub
+        run: |
+          jupyterhub --config /tmp/jupyterhub_config.py &
+          timeout 60 bash -c 'until curl -sf http://localhost:8000/hub/api/; do sleep 1; done'
+
+      - name: Spawn user server via Hub API
+        run: |
+          ADMIN_TOKEN=ci-admin-token
+          BASE=http://localhost:8000/hub/api
+
+          curl -sf -X POST -H "Authorization: token $ADMIN_TOKEN" $BASE/users/testuser
+          curl -sf -X POST -H "Authorization: token $ADMIN_TOKEN" $BASE/users/testuser/server
+
+          i=0
+          while [ $i -lt 60 ]; do
+            READY=$(curl -sf -H "Authorization: token $ADMIN_TOKEN" \
+              http://localhost:8000/hub/api/users/testuser \
+              | jq -r '.servers[""].ready // false')
+            [ "$READY" = "true" ] && break
+            i=$((i + 1))
+            sleep 2
+          done
+          [ "$READY" = "true" ] || { echo "Timed out waiting for user server to start"; exit 1; }
+
+          USER_TOKEN=$(curl -sf -X POST \
+            -H "Authorization: token $ADMIN_TOKEN" \
+            http://localhost:8000/hub/api/users/testuser/tokens \
+            | jq -r '.token')
+          echo "USER_TOKEN=$USER_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Test RStudio through JupyterHub proxy
+        run: |
+          HTTP_CODE=$(curl -s --max-time 60 \
+            -H "Authorization: token $USER_TOKEN" \
+            -c /tmp/hub_cookies.txt -b /tmp/hub_cookies.txt \
+            -L --max-redirs 5 \
+            -w "%{http_code}" -o /tmp/hub_rstudio_response.html \
+            http://localhost:8000/user/testuser/rstudio/) || true
+          echo "HTTP response code: $HTTP_CODE"
+
+          case "$HTTP_CODE" in
+            2*) ;;
+            *)
+              echo "--- Response body ---"
+              cat /tmp/hub_rstudio_response.html 2>/dev/null || echo "(no response body captured)"
+              exit 1
+              ;;
+          esac
+
+          grep -qi "rstudio" /tmp/hub_rstudio_response.html \
+            || { echo "Response does not contain RStudio content"; cat /tmp/hub_rstudio_response.html; exit 1; }
+          echo "RStudio is reachable through JupyterHub and served IDE content"

--- a/.github/workflows/test-jupyterlab.yaml
+++ b/.github/workflows/test-jupyterlab.yaml
@@ -1,6 +1,5 @@
-# This GitHub workflow installs RStudio Server alongside JupyterLab
-# and verifies the /rstudio/ proxy endpoint is reachable.
-name: Test
+# Installs RStudio Server alongside JupyterLab and verifies the /rstudio/ proxy endpoint is reachable.
+name: Test JupyterLab
 
 on:
   pull_request:
@@ -18,7 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-proxy:
+  test-jupyterlab:
     runs-on: ubuntu-latest
     container:
       image: quay.io/jupyter/r-notebook:latest
@@ -57,14 +56,17 @@ jobs:
             -c /tmp/rstudio_cookies.txt -b /tmp/rstudio_cookies.txt \
             -L --max-redirs 5 \
             -w "%{http_code}" -o /tmp/rstudio_response.html \
-            http://localhost:8888/rstudio/)
+            http://localhost:8888/rstudio/) || true
           echo "HTTP response code: $HTTP_CODE"
 
-          if [[ "$HTTP_CODE" != 2* ]]; then
-            echo "--- Response body ---"
-            cat /tmp/rstudio_response.html
-            exit 1
-          fi
+          case "$HTTP_CODE" in
+            2*) ;;
+            *)
+              echo "--- Response body ---"
+              cat /tmp/rstudio_response.html 2>/dev/null || echo "(no response body captured)"
+              exit 1
+              ;;
+          esac
 
           grep -qi "rstudio" /tmp/rstudio_response.html \
             || { echo "Response does not contain RStudio content"; cat /tmp/rstudio_response.html; exit 1; }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
             http://localhost:8888/rstudio/)
           echo "HTTP response code: $HTTP_CODE"
 
-          if [ "${HTTP_CODE:-0}" -lt 200 ] || [ "${HTTP_CODE:-0}" -ge 400 ]; then
+          if [[ "$HTTP_CODE" != 2* ]]; then
             echo "--- Response body ---"
             cat /tmp/rstudio_response.html
             exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,63 @@
+# This GitHub workflow installs RStudio Server alongside JupyterLab
+# and verifies the /rstudio/ proxy endpoint is reachable.
+name: Test
+
+on:
+  pull_request:
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+jobs:
+  test-proxy:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/jupyter/r-notebook:latest
+      options: --user root
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Install RStudio Server
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends gdebi-core jq wget
+
+          RELEASE=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          RSTUDIO_URL=$(wget --output-document - --output-file /dev/null \
+            'https://www.rstudio.com/wp-content/downloads.json' \
+            | jq --raw-output --arg RELEASE "$RELEASE" \
+              '.rstudio.open_source.stable.server.installer[$RELEASE].url')
+
+          wget --no-verbose --output-document rstudio-server-latest-amd64.deb "$RSTUDIO_URL"
+          gdebi --non-interactive rstudio-server-latest-amd64.deb
+          rm rstudio-server-latest-amd64.deb
+
+      - name: Start JupyterLab
+        run: |
+          jupyter lab --no-browser --ServerApp.token='' --ServerApp.password='' --allow-root &
+          timeout 60 bash -c 'until curl -sf http://localhost:8888/api; do sleep 1; done'
+
+      - name: Test Proxy
+        run: |
+          # Use a cookie jar so curl accumulates auth cookies across redirects.
+          HTTP_CODE=$(curl -s --max-time 60 \
+            -c /tmp/rstudio_cookies.txt -b /tmp/rstudio_cookies.txt \
+            -L --max-redirs 5 \
+            -w "%{http_code}" -o /tmp/rstudio_response.html \
+            http://localhost:8888/rstudio/)
+          echo "HTTP response code: $HTTP_CODE"
+
+          if [ "${HTTP_CODE:-0}" -lt 200 ] || [ "${HTTP_CODE:-0}" -ge 400 ]; then
+            echo "--- Response body ---"
+            cat /tmp/rstudio_response.html
+            exit 1
+          fi
+
+          grep -qi "rstudio" /tmp/rstudio_response.html \
+            || { echo "Response does not contain RStudio content"; cat /tmp/rstudio_response.html; exit 1; }
+          echo "RStudio is reachable and served IDE content"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,14 @@ name: Test
 
 on:
   pull_request:
+    branches:
+      - main
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+  push:
+    branches:
+      - main
     paths:
       - "**.py"
       - "pyproject.toml"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyter-rsession-proxy
 
-[![Test](https://github.com/jrdnbradford/jupyter-rsession-proxy/actions/workflows/test.yaml/badge.svg)](https://github.com/jrdnbradford/jupyter-rsession-proxy/actions/workflows/test.yaml)
+[![Test](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test.yaml/badge.svg)](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test.yaml)
 
 **jupyter-rsession-proxy** provides Jupyter server and notebook extensions to proxy RStudio.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyter-rsession-proxy
 
-[![TravisCI build status](https://img.shields.io/travis/com/jupyterhub/jupyter-rsession-proxy?logo=travis)](https://travis-ci.com/jupyterhub/jupyter-rsession-proxy)
+[![Test](https://github.com/jrdnbradford/jupyter-rsession-proxy/actions/workflows/test.yaml/badge.svg)](https://github.com/jrdnbradford/jupyter-rsession-proxy/actions/workflows/test.yaml)
 
 **jupyter-rsession-proxy** provides Jupyter server and notebook extensions to proxy RStudio.
 
@@ -59,7 +59,7 @@ Note: in this scenario, `jupyter-rsession-proxy` must still first be installed (
 ### Multiuser Considerations
 
 This extension launches an RStudio server process from the Jupyter notebook server. This is fine in JupyterHub deployments where user servers are containerized since other users cannot connect to the RStudio server port. In non-containerized JupyterHub deployments, for example on multiuser systems running LocalSpawner or BatchSpawner, *this is not secure if Rstudio server is listening on a TCP port*. In that case, any user may connect to Rstudio server and run arbitrary code. *However, if Rstudio is listening on a unix port, the socket will be protected using unix file permissions*. Therefore, we recommend keeping the default configuration, which uses a unix socket and not a TCP port.
- 
+
 ## Configuration with Environment Variables
 The following behavior can be configured with environment variables:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # jupyter-rsession-proxy
 
-[![Test](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test.yaml/badge.svg)](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test.yaml)
+[![Test JupyterLab](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test-jupyterlab.yaml/badge.svg)](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test-jupyterlab.yaml)
+[![Test JupyterHub](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test-jupyterhub.yaml/badge.svg)](https://github.com/jupyterhub/jupyter-rsession-proxy/actions/workflows/test-jupyterhub.yaml)
 
 **jupyter-rsession-proxy** provides Jupyter server and notebook extensions to proxy RStudio.
 


### PR DESCRIPTION
I used this test to verify changes I made in #179. It's a relatively simple one that uses an R notebook JupyterLab container, installs the latest open source RStudio Server, and verifies the `rstudio` endpoint is reachable through the proxy.

I've verified that this test fails for `jupyter-rsession-proxy==2.5.0` (the affected release) but passes for code on #179 and the previous release.

This PR also removes the stale TravisCI status badge, replacing it with the new GHA badge.

Happy to make changes!

